### PR TITLE
nit: use already created reference instead of property access

### DIFF
--- a/src/LruMap.js
+++ b/src/LruMap.js
@@ -25,7 +25,7 @@ export class LruMap {
     const prev = item.prev
 
     if (this.first === item) {
-      this.first = item.next
+      this.first = next
     }
 
     item.next = null

--- a/src/LruMap.js
+++ b/src/LruMap.js
@@ -29,7 +29,7 @@ export class LruMap {
     }
 
     item.next = null
-    item.prev = this.last
+    item.prev = last
     last.next = item
 
     if (prev !== null) {
@@ -142,6 +142,7 @@ export class LruMap {
       if (this.last !== item) {
         this.bumpLru(item)
       }
+
       return
     }
 

--- a/src/LruObject.js
+++ b/src/LruObject.js
@@ -22,7 +22,7 @@ export class LruObject {
     const prev = item.prev
 
     if (this.first === item) {
-      this.first = item.next
+      this.first = next
     }
 
     item.next = null

--- a/src/LruObject.js
+++ b/src/LruObject.js
@@ -26,7 +26,7 @@ export class LruObject {
     }
 
     item.next = null
-    item.prev = this.last
+    item.prev = last
     last.next = item
 
     if (prev !== null) {
@@ -141,6 +141,7 @@ export class LruObject {
       if (this.last !== item) {
         this.bumpLru(item)
       }
+
       return
     }
 


### PR DESCRIPTION
I was reading the source code when this hit me...

Why create a `const` object reference and not use it afterward... 🤣

Jokes aside, just wanted to point out that you can either remove that declaration or use it instead of accessing `this` again 🙏