### PR TITLE
fix(LruObject): do not bumb entry if there is only one entry

### DIFF
--- a/src/LruMap.js
+++ b/src/LruMap.js
@@ -20,6 +20,10 @@ export class LruMap {
   }
 
   bumpLru(item) {
+    if (this.last === item) {
+      return // Item is already the last one, no need to bump
+    }
+
     const last = this.last
     const next = item.next
     const prev = item.prev

--- a/src/LruObject.js
+++ b/src/LruObject.js
@@ -110,8 +110,11 @@ export class LruObject {
         return
       }
 
-      // Item is still fresh
-      this.bumpLru(item)
+      if (this.size !== 1) {
+        // Item is still fresh & needs to be bumped
+        this.bumpLru(item)
+      }
+
       return item.value
     }
   }

--- a/src/LruObject.js
+++ b/src/LruObject.js
@@ -116,7 +116,6 @@ export class LruObject {
 
       // Item is still fresh
       this.bumpLru(item)
-
       return item.value
     }
   }

--- a/src/LruObject.js
+++ b/src/LruObject.js
@@ -17,6 +17,10 @@ export class LruObject {
   }
 
   bumpLru(item) {
+    if (this.last === item) {
+      return // Item is already the last one, no need to bump
+    }
+
     const last = this.last
     const next = item.next
     const prev = item.prev
@@ -110,10 +114,8 @@ export class LruObject {
         return
       }
 
-      if (this.size !== 1) {
-        // Item is still fresh & needs to be bumped
-        this.bumpLru(item)
-      }
+      // Item is still fresh
+      this.bumpLru(item)
 
       return item.value
     }

--- a/test/LruMap.spec.js
+++ b/test/LruMap.spec.js
@@ -82,6 +82,34 @@ describe('LruMap', function () {
       expect(item2Pre).toBe(items[2])
       expect(item2Post).toBe(items[2])
     })
+
+    it('does not overwrite cache.first', async () => {
+      cache = new LruMap(5, 500)
+
+      const key = '10.0.0.1'
+      const value = 100
+
+      cache.set(key, value)
+      expect(cache.first).not.toBeNull()
+
+      cache.get(key)
+      expect(cache.first).not.toBeNull()
+    })
+
+    it('does not cause TypeError when reaching the cache limit', async () => {
+      const maxCacheSize = 3
+      cache = new LruMap(maxCacheSize, 500)
+
+      const key = '10.0.0.1'
+      const value = 100
+
+      cache.set(key, value)
+      cache.get(key)
+
+      for (let i = 0; i < maxCacheSize; i++) {
+        cache.set(i, i)
+      }
+    })
   })
 
   describe('getMany', () => {

--- a/test/LruObject.spec.js
+++ b/test/LruObject.spec.js
@@ -82,6 +82,34 @@ describe('LruObject', function () {
       expect(item2Pre).toBe(items[2])
       expect(item2Post).toBe(items[2])
     })
+
+    it('does not overwrite cache.first', async () => {
+      cache = new LruObject(5, 500)
+
+      const key = '10.0.0.1'
+      const value = 100
+
+      cache.set(key, value)
+      expect(cache.first).not.toBeNull()
+
+      cache.get(key)
+      expect(cache.first).not.toBeNull()
+    })
+
+    it('does not cause TypeError when reaching the cache limit', async () => {
+      const maxCacheSize = 3
+      cache = new LruObject(maxCacheSize, 500)
+
+      const key = '10.0.0.1'
+      const value = 100
+
+      cache.set(key, value)
+      cache.get(key)
+
+      for (let i = 0; i < maxCacheSize; i++) {
+        cache.set(i, i)
+      }
+    })
   })
 
   describe('getMany', () => {


### PR DESCRIPTION
fixes https://github.com/kibertoad/toad-cache/issues/32

---

update: I saw that `LruMap` is affected by the same bug and fixed it there as well