### PR TITLE
build(deps-dev): lock typescript minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rollup": "^4.6.0",
     "vitest": "^2.0.1",
     "tsd": "^0.31.0",
-    "typescript": "^5.3.3"
+    "typescript": "~5.3.3"
   },
   "keywords": [
     "LRU",


### PR DESCRIPTION
See https://github.com/fastify/fastify-type-provider-typebox/pull/169#issuecomment-2421682145, TypeScript uses major and minor for breaking changes.

This way [Dependabot will still update for minors](https://github.com/fastify/fastify-type-provider-typebox/pull/177), which will flag breaking changes if tests fail.