### PR TITLE
build(dependabot): reduce npm updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "rollup"


### PR DESCRIPTION
Similar reasoning as https://github.com/fastify/fastify/pull/5939, toad-cache doesn't get released on a regular schedule for this to be needed.