### PR TITLE
chore: drop support for node < 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Checkout Repository

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,7 @@
 			"arrowParentheses": "always",
 			"indentStyle": "space",
 			"semicolons": "asNeeded",
-			"trailingComma": "all",
+			"trailingCommas": "all",
 			"lineWidth": 100,
 			"quoteStyle": "single"
 		}

--- a/package.json
+++ b/package.json
@@ -53,16 +53,15 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.5.3",
-    "@vitest/coverage-v8": "^2.0.1",
-    "@rollup/plugin-terser": "^0.4.4",
-    "auto-changelog": "^2.4.0",
+    "@biomejs/biome": "^1.9.4",
+    "@vitest/coverage-v8": "^3.0.8",
+    "auto-changelog": "^2.5.0",
     "del-cli": "^6.0.0",
-    "precise": "^4.0.0",
-    "rollup": "^4.6.0",
-    "vitest": "^2.0.1",
-    "tsd": "^0.31.0",
-    "typescript": "~5.3.3"
+    "precise": "^4.0.3",
+    "rollup": "^4.35.0",
+    "tsd": "^0.31.2",
+    "typescript": "~5.8.2",
+    "vitest": "^3.0.8"
   },
   "keywords": [
     "LRU",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "type": "module",
   "sourceType": "module",
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "engineStrict": true,
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import terser from "@rollup/plugin-terser";
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const pkg = require("./package.json");


### PR DESCRIPTION
This PR:
- Drops support for Node < 20 (breaking change)
- Bumps dev dependencies to their latest versions, resolving vulnerabilities raised by `npm audit`
- Removes the unused `@rollup/plugin-terser` plugin
- Replaces the deprecated `trailingComma` biome config value with `trailingCommas`