### PR TITLE
ci: update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -22,15 +25,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           always-auth: false
+          check-latest: true
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Build
         run: npm run rollup
@@ -40,6 +45,9 @@ jobs:
 
   automerge:
     needs: build
+    if: >
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
     name: coverage
 
@@ -21,15 +24,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Setup Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           always-auth: false
+          check-latest: true
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm install --ignore-scripts
 
       - name: Run Tests
         run: npm run test:coverage


### PR DESCRIPTION
Last PR, I promise!

This PR:

-   Removes Git credentials after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script; [see related GitHub security post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) and [related actions/checkout issue](https://github.com/actions/checkout/issues/485)
-   Declares the minimum permissions for the workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Set `check-latest` to true, so that the `actions/setup-node` will check it is using the latest minor or hotfix Node version and use that instead of its cached version, this stops an issue like with 22.5.0 that introduced a regression and actions were still using that instead of 22.5.1
-  Updates `automerge` job to check if the user triggering job is dependabot (same as what Fastify repos do)
-  Adds `--ignore-scripts` arg to `npm install` calls, preventing any potentially harmful lifecycle scripts that may have snuck in