### PR TITLE
ci: add zizmor security audit and address findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: npm
     directory: "/"
     schedule:
@@ -32,3 +34,5 @@ updates:
           - "ts-node"
           - "ts-node-dev"
           - "typescript"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,30 @@ permissions:
   contents: read
 
 jobs:
+  zizmor:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.13'
+
+      - name: Install zizmor
+        run: pip install zizmor==1.24.1
+
+      - name: Run zizmor
+        run: zizmor --format=github --min-severity=low .
+
   build:
     permissions:
       contents: read
@@ -25,16 +49,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,16 +24,16 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           check-latest: true
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Add a zizmor job to the CI workflow that audits GitHub Actions
workflows on every push and pull request, failing the build on any
finding (--min-severity=low).

Resolve all current findings reported on the regular persona:

- Pin actions/checkout, actions/setup-node, and pnpm/action-setup to
  commit SHAs in ci.yml and coverage.yml (unpinned-uses).
- Add a default 7-day cooldown to both Dependabot ecosystems
  (dependabot-cooldown).