### PR TITLE
ci: OIDC-based npm publish workflow + release-label enforcement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+    labels:
+      - skip-release
     cooldown:
       default-days: 7
   - package-ecosystem: npm
@@ -12,6 +14,8 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 10
+    labels:
+      - skip-release
     ignore:
       - dependency-name: "rollup"
       - dependency-name: "@rollup/*"

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,36 @@
+---
+name: label-check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a release label
+        env:
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "PR labels: $LABELS"
+          case "$LABELS" in
+            *'"patch"'*|*'"minor"'*|*'"major"'*|*'"skip-release"'*)
+              echo "Required release label is set."
+              ;;
+            *)
+              echo "::error::PR must have one of these labels: patch, minor, major, skip-release"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+---
+name: publish
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'patch') || contains(github.event.pull_request.labels.*.name, 'minor') || contains(github.event.pull_request.labels.*.name, 'major'))
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Determine version bump
+        id: version
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Bump version
+        env:
+          VERSION_BUMP: ${{ steps.version.outputs.bump }}
+        run: |
+          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
+          git push
+          git push --tags
+
+      - name: Publish to npm
+        run: pnpm publish --access public --provenance --no-git-checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -62,10 +63,13 @@ jobs:
       - name: Bump version
         env:
           VERSION_BUMP: ${{ steps.version.outputs.bump }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           pnpm version "$VERSION_BUMP" -m "chore: release v%s"
-          git push
-          git push --tags
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "$REMOTE" "HEAD:${BASE_REF}"
+          git push "$REMOTE" --tags
 
       - name: Publish to npm
         run: pnpm publish --access public --provenance --no-git-checks

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Igor Savin <kibertoad@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kibertoad/toad-cache.git"
+    "url": "git+https://github.com/kibertoad/toad-cache.git"
   },
   "bugs": {
     "url": "https://github.com/kibertoad/toad-cache/issues"


### PR DESCRIPTION
## Summary
- Add `publish.yml` that runs on merged PRs labelled `patch`/`minor`/`major`, bumps the version, pushes a tag, and publishes to npm using OIDC trusted publishing (`id-token: write`) with `--provenance`. Mirrors the workflow used in [toad-scheduler](https://github.com/kibertoad/toad-scheduler/blob/main/.github/workflows/publish.yml); actions are pinned by commit SHA.
- Add `label-check.yml` that fails the PR check unless one of `patch`, `minor`, `major`, or `skip-release` is set, so release intent is always explicit.
- Pre-label all dependabot PRs with `skip-release` so they aren't blocked by the new gate.
- Normalize `repository.url` in `package.json` from `git://` to `git+https://`, the form npm provenance expects.

## Follow-ups (out of band, not in this PR)
- On npmjs.com → `toad-cache` → Settings → Publishing access, register a Trusted Publisher pointing at this repo + `publish.yml`. Without this, npm won't accept the OIDC token.
- Create the labels (`patch`, `minor`, `major`, `skip-release`) in the repo if they don't already exist — dependabot can only apply `skip-release` if the label exists.
- Optionally mark `label-check` as a required status check in branch protection.

## Test plan
- [ ] Open a PR with no release label → `label-check` fails.
- [ ] Add `skip-release` → `label-check` passes, `publish` does not run on merge.
- [ ] Merge a PR labelled `patch` → `publish` runs, version bumps, tag is pushed, npm publish succeeds with provenance (requires the trusted-publisher setup above).
- [ ] Next dependabot PR opens with `skip-release` already attached and existing auto-merge keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)