### PR TITLE
ci: auto-create GitHub release on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,15 +60,23 @@ jobs:
           fi
 
       - name: Bump version
+        id: bump
         env:
           VERSION_BUMP: ${{ steps.version.outputs.bump }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
+          NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
+          echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
           REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push "$REMOTE" "HEAD:${BASE_REF}"
           git push "$REMOTE" --tags
 
       - name: Publish to npm
         run: pnpm publish --access public --provenance --no-git-checks
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.bump.outputs.tag }}
+        run: gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes


### PR DESCRIPTION
## Summary
- Capture new tag from `pnpm version` output into a step output
- After `pnpm publish`, run `gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes` so each published version gets a matching GitHub release with auto-generated notes from merged PRs/commits since the previous tag
- Tag creation/push was already handled (`pnpm version` + `git push --tags`); this just adds the release entry on top
- Release step runs after npm publish, so a failed publish won't leave a release pointing at a missing version on npm

## Test plan
- [ ] Merge a follow-up PR with a `patch`/`minor`/`major` label and confirm a new GitHub release appears under https://github.com/kibertoad/toad-cache/releases with auto-generated notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)