### PR TITLE
ci: fix release publish broken by pnpm version output format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
+          pnpm version "$VERSION_BUMP" -m "chore: release v%s"
+          NEW_VERSION="v$(node -p "require('./package.json').version")"
           echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
           REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push "$REMOTE" "HEAD:${BASE_REF}"


### PR DESCRIPTION
## What broke

The `publish` workflow has failed on every release since 3.7.2. npm's `latest` is still **3.7.1**, even though `v3.7.2` and `v3.7.3` commits and tags were pushed. The npm publish and GitHub release steps never ran.

## Root cause

The `Bump version` step captured `pnpm version` stdout:

```bash
NEW_VERSION=$(pnpm version "$VERSION_BUMP" -m "chore: release v%s")
echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
```

Unlike `npm version` (which prints `v3.7.3`), pnpm prints `toad-cache: 3.7.2 → 3.7.3`. Writing that to `$GITHUB_OUTPUT` fails with `Invalid format`, so the job dies right after pushing the tag, before publishing.

## Fix

Read the bumped version from `package.json` instead of parsing pnpm stdout:

```bash
pnpm version "$VERSION_BUMP" -m "chore: release v%s"
NEW_VERSION="v$(node -p "require('./package.json').version")"
echo "tag=${NEW_VERSION}" >> $GITHUB_OUTPUT
```

## Note on this PR

Do **not** add a release label to this PR. The `pull_request: closed` event runs the workflow file from the base branch, i.e. the still-broken version, so a labeled merge here would fail again. Merge unlabeled, then the next labeled PR will publish correctly.

## Recovery still needed

3.7.2 and 3.7.3 are missing from npm. See merge comment for options.